### PR TITLE
Remove email addresses from contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,17 +343,9 @@
       </div>
       <p class="contact-lede">
         Want to talk robots, motion planning, or a problem that needs someone who can make
-        hardware move? My inbox is open.
+        hardware move? Reach out on LinkedIn.
       </p>
       <ul class="contact-list">
-        <li>
-          <span class="mono contact-label">email</span>
-          <a href="mailto:tgjohnson0511@gmail.com">tgjohnson0511@gmail.com</a>
-        </li>
-        <li>
-          <span class="mono contact-label">alt email</span>
-          <a href="mailto:tgj@alumni.cmu.edu">tgj@alumni.cmu.edu</a>
-        </li>
         <li>
           <span class="mono contact-label">linkedin</span>
           <a href="https://www.linkedin.com/in/tylergjohnson0511" target="_blank"


### PR DESCRIPTION
## Summary

Removes both email addresses (gmail + CMU alumni) from the contact section. The contact lede now points visitors to LinkedIn instead; LinkedIn and GitHub remain as contact methods.

This was committed to the redesign branch after #10 was merged, so it needed its own PR — cherry-picked onto main.

## Test plan
- [x] `grep -i "mailto\|gmail\|cmu.edu"` across the site returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)