### PR TITLE
About: drop 'systems' from CMU focus areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
           <dl class="edu mono">
             <div>
               <dt>MS ECE</dt>
-              <dd>Carnegie Mellon University — computer vision, AI, robotics, systems, security</dd>
+              <dd>Carnegie Mellon University — computer vision, AI, robotics, security</dd>
             </div>
             <div>
               <dt>BS ECE</dt>


### PR DESCRIPTION
## Summary

Tiny copy edit in the about section's education block: the MS ECE line now reads "computer vision, AI, robotics, security" (removed "systems").

🤖 Generated with [Claude Code](https://claude.com/claude-code)