### PR TITLE
Experience: add public Locus Array details to Locus entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
 
   <title>Tyler Johnson — Senior Robotics Software Engineer</title>
   <meta name="description"
-    content="Tyler Johnson is a senior robotics software engineer specializing in motion planning, manipulation, and control — currently building warehouse robotics at Locus Robotics.">
+    content="Tyler Johnson is a senior robotics software engineer specializing in motion planning, manipulation, and control — currently building Locus Array, fully autonomous fulfillment robots, at Locus Robotics.">
   <link rel="canonical" href="https://johnsontyler0511.github.io/">
   <meta name="theme-color" content="#0a0e12">
 
   <meta property="og:title" content="Tyler Johnson — Senior Robotics Software Engineer">
   <meta property="og:description"
-    content="Motion planning, manipulation, and control software for industrial robots. Currently building warehouse robotics at Locus Robotics.">
+    content="Motion planning, manipulation, and control software for industrial robots. Currently building Locus Array at Locus Robotics.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://johnsontyler0511.github.io/">
   <meta property="og:image" content="https://johnsontyler0511.github.io/images/og-image.jpg">
@@ -76,8 +76,9 @@
       <h1>Tyler Johnson</h1>
       <p class="hero-tagline">
         I build the software that makes industrial robots move — motion planning, manipulation,
-        control, and the interfaces that let the outside world drive them. Currently shipping
-        warehouse robotics at <strong>Locus Robotics</strong>.
+        control, and the interfaces that let the outside world drive them. Currently building
+        <strong>Locus Array</strong>, a new class of fully autonomous fulfillment robots, at
+        <strong>Locus Robotics</strong>.
       </p>
       <ul class="hero-chips mono" aria-label="Focus areas">
         <li>motion planning</li>
@@ -160,9 +161,21 @@
               <p class="role">Senior Robotics Software Engineer <span class="badge mono">current</span></p>
             </header>
             <p>
-              Building the software that keeps warehouse robot fleets moving — motion, autonomy, and the
-              systems that let hundreds of robots share a building with people and get product out the door.
+              I work on the <a href="https://locusrobotics.com/array" target="_blank"
+                rel="noopener">Locus Array</a> team, developing the core systems that run the robot —
+              the foundation the rest of the machine builds on. Array is Locus's new Robots-to-Goods
+              platform: a fully autonomous fulfillment robot that drives to inventory and picks, puts
+              away, and replenishes on its own, pairing a mobile base with a robotic arm and AI-powered
+              perception, orchestrated across the fleet by LocusONE.
             </p>
+            <div class="highlight">
+              <p class="mono highlight-label">&gt; in the wild</p>
+              <p>
+                Array launched at MODEX 2026 and is already running in live customer warehouses. Most of
+                what makes it tick stays in the building — but watching one machine work an aisle end to
+                end, with nobody in the loop, says plenty on its own.
+              </p>
+            </div>
             <p class="mono tech-tags">C++ &middot; Python &middot; ROS 2</p>
           </article>
         </li>


### PR DESCRIPTION
## Summary

Updates the Locus Robotics experience entry to reflect Tyler's role on the **Locus Array** team, using only publicly announced information (MODEX 2026 launch, Robots-to-Goods category, mobile base + robotic arm + AI perception, LocusONE orchestration, live customer deployments).

- Experience entry: core-systems role on the Array team, with a "> in the wild" highlight block — deliberately understated, no non-public details
- Hero tagline + meta/OG descriptions now mention Locus Array
- Links to the official Array product page (URL verified 200)

## Test plan
- [x] Array product link returns 200
- [x] Wording reviewed against public press coverage only

🤖 Generated with [Claude Code](https://claude.com/claude-code)