### PR TITLE
Contact: neutral tone instead of inviting outreach

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,8 +342,7 @@
         <span class="rule" aria-hidden="true"></span>
       </div>
       <p class="contact-lede">
-        Want to talk robots, motion planning, or a problem that needs someone who can make
-        hardware move? Reach out on LinkedIn.
+        Elsewhere on the internet — the professional record is on LinkedIn, the code is on GitHub.
       </p>
       <ul class="contact-list">
         <li>


### PR DESCRIPTION
## Summary

Replaces the contact section's invitation ("Want to talk robots… Reach out on LinkedIn.") with a neutral pointer: "Elsewhere on the internet — the professional record is on LinkedIn, the code is on GitHub."

🤖 Generated with [Claude Code](https://claude.com/claude-code)