### PR TITLE
Locus entry: drop highlight block, single understated paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,21 +161,13 @@
               <p class="role">Senior Robotics Software Engineer <span class="badge mono">current</span></p>
             </header>
             <p>
-              I work on the <a href="https://locusrobotics.com/array" target="_blank"
-                rel="noopener">Locus Array</a> team, developing the core systems that run the robot —
-              the foundation the rest of the machine builds on. Array is Locus's new Robots-to-Goods
-              platform: a fully autonomous fulfillment robot that drives to inventory and picks, puts
-              away, and replenishes on its own, pairing a mobile base with a robotic arm and AI-powered
-              perception, orchestrated across the fleet by LocusONE.
+              I develop the software that runs the <a href="https://locusrobotics.com/array"
+                target="_blank" rel="noopener">Locus Array</a> robot — Locus's new Robots-to-Goods
+              platform, a fully autonomous fulfillment robot that drives to inventory and picks, puts
+              away, and replenishes on its own. A machine like that is a lot of software working in
+              concert, and my work tends to run through all of it, wherever the robot needs it that
+              week. Beyond that, I can't say much — most of what makes Array tick stays in the building.
             </p>
-            <div class="highlight">
-              <p class="mono highlight-label">&gt; in the wild</p>
-              <p>
-                Array launched at MODEX 2026 and is already running in live customer warehouses. Most of
-                what makes it tick stays in the building — but watching one machine work an aisle end to
-                end, with nobody in the loop, says plenty on its own.
-              </p>
-            </div>
             <p class="mono tech-tags">C++ &middot; Python &middot; ROS 2</p>
           </article>
         </li>


### PR DESCRIPTION
## Summary

Follow-up to #13 (this commit landed on that branch just after it merged, so it needed its own PR). Removes the "> in the wild" highlight block from the Locus Robotics entry and tightens it to one understated paragraph: develops the software that runs the whole Locus Array robot, work runs through all of it, details stay in the building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)