### PR TITLE
Align title and location with LinkedIn profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # johnsonTyler0511.github.io
 
-Personal portfolio of **Tyler Johnson** — senior robotics software engineer.
+Personal portfolio of **Tyler Johnson** — senior robotics engineer in Boston.
 
 **Live:** https://johnsontyler0511.github.io
 

--- a/index.html
+++ b/index.html
@@ -5,13 +5,13 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Tyler Johnson — Senior Robotics Software Engineer</title>
+  <title>Tyler Johnson — Senior Robotics Engineer</title>
   <meta name="description"
-    content="Tyler Johnson is a senior robotics software engineer specializing in motion planning, manipulation, and control — currently building Locus Array, fully autonomous fulfillment robots, at Locus Robotics.">
+    content="Tyler Johnson is a senior robotics engineer in Boston specializing in motion planning, manipulation, and control — currently building Locus Array, fully autonomous fulfillment robots, at Locus Robotics.">
   <link rel="canonical" href="https://johnsontyler0511.github.io/">
   <meta name="theme-color" content="#0a0e12">
 
-  <meta property="og:title" content="Tyler Johnson — Senior Robotics Software Engineer">
+  <meta property="og:title" content="Tyler Johnson — Senior Robotics Engineer">
   <meta property="og:description"
     content="Motion planning, manipulation, and control software for industrial robots. Currently building Locus Array at Locus Robotics.">
   <meta property="og:type" content="website">
@@ -20,7 +20,7 @@
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Tyler Johnson — Senior Robotics Software Engineer">
+  <meta name="twitter:title" content="Tyler Johnson — Senior Robotics Engineer">
   <meta name="twitter:description"
     content="Motion planning, manipulation, and control software for industrial robots.">
   <meta name="twitter:image" content="https://johnsontyler0511.github.io/images/og-image.jpg">
@@ -37,8 +37,9 @@
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Tyler Johnson",
-    "jobTitle": "Senior Robotics Software Engineer",
+    "jobTitle": "Senior Robotics Engineer",
     "worksFor": { "@type": "Organization", "name": "Locus Robotics" },
+    "address": { "@type": "PostalAddress", "addressLocality": "Boston", "addressRegion": "MA" },
     "alumniOf": [
       { "@type": "CollegeOrUniversity", "name": "Carnegie Mellon University" },
       { "@type": "CollegeOrUniversity", "name": "University of Florida" }
@@ -72,7 +73,7 @@
 
     <!-- ============================== Hero ============================== -->
     <section class="hero container" id="top">
-      <p class="mono eyebrow">// senior robotics software engineer</p>
+      <p class="mono eyebrow">// senior robotics engineer · boston, ma</p>
       <h1>Tyler Johnson</h1>
       <p class="hero-tagline">
         I build the software that makes industrial robots move — motion planning, manipulation,
@@ -158,7 +159,7 @@
           <article>
             <header class="entry-head">
               <h3>Locus Robotics</h3>
-              <p class="role">Senior Robotics Software Engineer <span class="badge mono">current</span></p>
+              <p class="role">Senior Robotics Engineer <span class="badge mono">current</span></p>
             </header>
             <p>
               I develop the software that runs the <a href="https://locusrobotics.com/array"
@@ -350,6 +351,10 @@
         Elsewhere on the internet — the professional record is on LinkedIn, the code is on GitHub.
       </p>
       <ul class="contact-list">
+        <li>
+          <span class="mono contact-label">location</span>
+          <span>Boston, Massachusetts</span>
+        </li>
         <li>
           <span class="mono contact-label">linkedin</span>
           <a href="https://www.linkedin.com/in/tylergjohnson0511" target="_blank"


### PR DESCRIPTION
## Summary

Comb-over against Tyler's LinkedIn profile (PDF export, June 2026). Two alignments:

- **Title**: LinkedIn headline is "Senior Robotics Engineer" — the site said "Senior Robotics **Software** Engineer" (assumed during the rebuild). Updated everywhere it refers to the current role: page title, meta/OG/Twitter descriptions, JSON-LD jobTitle, hero eyebrow, and the Locus experience entry. KUKA/Kawasaki historical titles unchanged.
- **Location**: added Boston — hero eyebrow (`// senior robotics engineer · boston, ma`), contact list row, meta description, and JSON-LD address.

## Test plan
- [x] JSON-LD parses as valid JSON
- [x] No remaining "Robotics Software Engineer" references to the current role

🤖 Generated with [Claude Code](https://claude.com/claude-code)