### PR TITLE
Munch Mayhem card: tighten description

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,19 +313,11 @@
           <div class="card-body">
             <h3>Munch Mayhem <span class="mono card-note">Godot prototype</span></h3>
             <p>
-              An idle/tycoon game built in Godot 4 as a structured case study in agentic software
-              engineering — driving a project from an empty editor to a playable build through a
-              deliberate, AI-assisted development workflow. The MVP ships three upgradeable stations, an
-              idle economy with prestige-style gear multipliers, and versioned JSON save/load, with
-              placeholder art keeping the focus on system design and engineering process.
-            </p>
-            <p>
-              Each kitchen is a procedurally generated floor plan: a Voronoi tessellation with Lloyd
-              relaxation and jittered-grid seeding partitions the space into rooms, merges undersized
-              cells, then carves doorways and a front entrance before placing equipment — the winning
-              strategy out of a sandbox that benchmarked 13+ generation algorithms (BSP, cellular
-              automata, and several Voronoi distance metrics). A sous-chef then navigates the layout
-              via A* pathfinding over the walkable tiles.
+              An idle/tycoon game built in Godot 4 as a deliberate agentic software engineering case
+              study — taking a project from an empty editor to a playable build through an AI-assisted
+              workflow. Each kitchen is a procedurally generated floor plan, built with a Voronoi
+              tessellation and Lloyd relaxation chosen from a sandbox that benchmarked 13+ generation
+              algorithms.
             </p>
             <p class="mono tech-tags">Godot 4 &middot; GDScript &middot; Procedural Generation</p>
           </div>


### PR DESCRIPTION
Follow-up to #19. The Munch Mayhem description had grown longer than the other project cards.

- Collapses the two paragraphs into **one concise paragraph** in parity with the other cards.
- Keeps the strongest points: **agentic software engineering** framing (empty editor → playable build) and **Voronoi + Lloyd-relaxation procgen** chosen from a **13+ algorithm sandbox**.
- **Drops the A\* pathfinding mention** — the Motion Planning Playground card already covers path planning, so it was redundant here.
- Tech tags unchanged (`Godot 4 · GDScript · Procedural Generation`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)