### PR TITLE
Drop stack brag from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,7 +387,7 @@
   <footer class="site-footer">
     <div class="container">
       <p class="mono">
-        &copy; <span id="year">2026</span> Tyler Johnson &middot; built with plain HTML, CSS &amp; JS &middot;
+        &copy; <span id="year">2026</span> Tyler Johnson &middot;
         <a href="https://github.com/johnsonTyler0511/johnsonTyler0511.github.io" target="_blank"
           rel="noopener">source</a>
       </p>


### PR DESCRIPTION
Removes "built with plain HTML, CSS & JS" from the site footer — leaves `© Tyler Johnson · source`.

Internal `README.md` / `css/main.css` comments describing the stack are left as-is (dev docs, not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)