### PR TITLE
Add AIC Connector Insertion project

### DIFF
--- a/aic.html
+++ b/aic.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>AIC Connector Insertion — Tyler Johnson</title>
+  <meta name="description"
+    content="Team entry to Intrinsic's AI for Industry Challenge: a fine-tuned SmolVLA vision-language-action policy for robotic fiber-optic connector insertion, nearly tripling the provided baseline.">
+  <link rel="canonical" href="https://johnsontyler0511.github.io/aic.html">
+  <meta name="theme-color" content="#0a0e12">
+
+  <meta property="og:title" content="AIC Connector Insertion — Tyler Johnson">
+  <meta property="og:description"
+    content="Fine-tuned SmolVLA for robotic fiber-optic connector insertion — imitation learning, ROS 2, and an honest experiment log.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://johnsontyler0511.github.io/aic.html">
+
+  <link rel="icon" href="/favicon.ico" sizes="32x32">
+  <link rel="icon" href="/images/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+
+  <link rel="stylesheet" href="css/main.css">
+  <script src="js/main.js" defer></script>
+</head>
+
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <nav class="container" aria-label="Primary">
+      <a class="brand" href="index.html"><span class="brand-prompt">~$</span> tyler.johnson</a>
+      <ul class="nav-links">
+        <li><a href="index.html#projects">&larr; back to projects</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main id="main">
+
+    <!-- ============================== Hero ============================== -->
+    <section class="project-hero container">
+      <p class="mono eyebrow">// project &middot; imitation learning &middot; robot manipulation</p>
+      <h1>AIC Connector Insertion <span class="mono card-note">private repo &mdash; code cannot be shared</span></h1>
+      <p class="project-lede">
+        Team entry to Intrinsic's <strong>AI for Industry Challenge</strong>: teaching a simulated
+        UR5e to plug fiber-optic connectors into a networking task board with a fine-tuned
+        vision-language-action model. Built with <strong>Abhijit Makhal</strong> and
+        <strong>Amrit Saini</strong>. The repo is private, so this page documents the system,
+        the experiments, and the results.
+      </p>
+      <p class="mono tech-tags">ROS 2 &middot; LeRobot &middot; SmolVLA &middot; Gazebo &middot; Python &middot; C++</p>
+    </section>
+
+    <!-- ============================== Overview ============================== -->
+    <section class="container" id="overview" data-reveal>
+      <div class="section-head">
+        <span class="mono section-num">01 / overview</span>
+        <h2>Overview</h2>
+        <span class="rule" aria-hidden="true"></span>
+      </div>
+      <div class="prose">
+        <p>
+          The challenge is dexterous cable insertion: a UR5e arm in Gazebo must pick up SFP and SC
+          fiber-optic connectors and seat them in ports on a task board &mdash; a peg-in-hole problem
+          that demands sub-centimeter precision under randomized start poses, impedance settings, and
+          force disturbances. The organizers run a fixed C++ evaluation stack; participants submit a
+          single Python policy that answers one ROS 2 action. Scoring rewards proximity, smoothness,
+          and above all insertion depth, and punishes collisions.
+        </p>
+        <p>
+          We went with a learned approach: collect demonstrations from a ground-truth oracle policy,
+          convert them into a LeRobot dataset, and fine-tune <strong>SmolVLA</strong> &mdash; a small
+          vision-language-action model &mdash; to imitate them. Over a documented experiment campaign
+          the policy went from the provided ACT baseline's <strong>38.2</strong> to
+          <strong>110.3</strong>, close to a 3&times; improvement.
+        </p>
+      </div>
+    </section>
+
+    <!-- ============================== System ============================== -->
+    <section class="container" id="system" data-reveal>
+      <div class="section-head">
+        <span class="mono section-num">02 / system</span>
+        <h2>System</h2>
+        <span class="rule" aria-hidden="true"></span>
+      </div>
+      <div class="prose">
+        <figure class="diagram" data-reveal>
+          <img src="images/aic-system.svg"
+            alt="System architecture: the organizers' C++ evaluation stack (aic_engine, aic_controller, aic_adapter, Gazebo) exchanges camera, wrench, and joint-state observations and 6-DOF twist commands with the team's Python participant model over the /insert_cable ROS 2 action"
+            width="800" height="450" loading="lazy" decoding="async">
+          <figcaption class="mono">two components, one action interface</figcaption>
+        </figure>
+        <p>
+          Everything meets at one boundary. The evaluation side owns the physics: an engine that
+          orchestrates and scores trials, an impedance controller, and a sensor-fusion adapter around
+          a Gazebo simulation of the arm and task board. Our side is a ROS 2 lifecycle node that
+          dynamically loads a <code>Policy</code> and answers the <code>/insert_cable</code> action
+          &mdash; consuming camera images, wrench readings, and joint states, and streaming back
+          6-DOF Cartesian twist commands. The stack runs on ROS 2 Kilted over the Zenoh RMW, with the
+          submission executing inside a resource-limited container (a 30-second model-discovery budget
+          included &mdash; heavy imports can silently kill a run).
+        </p>
+      </div>
+    </section>
+
+    <!-- ============================== Pipeline ============================== -->
+    <section class="container" id="pipeline" data-reveal>
+      <div class="section-head">
+        <span class="mono section-num">03 / data pipeline</span>
+        <h2>Data &amp; Training Pipeline</h2>
+        <span class="rule" aria-hidden="true"></span>
+      </div>
+      <div class="prose">
+        <figure class="diagram" data-reveal>
+          <img src="images/aic-pipeline.svg"
+            alt="Four-stage imitation learning loop: generate randomized trial configs, roll out the CheatCode oracle in Gazebo to produce rosbags and scores, filter and convert successes into a LeRobot dataset, fine-tune and evaluate SmolVLA, then iterate"
+            width="800" height="500" loading="lazy" decoding="async">
+          <figcaption class="mono">the imitation-learning loop</figcaption>
+        </figure>
+        <p>
+          Demonstrations come from <em>CheatCode</em>, an oracle policy that reads ground-truth
+          transforms the real submission never sees. Stage one generates randomized trial configs
+          &mdash; start-pose jitter, impedance randomization, injected force disturbances, scene
+          clutter &mdash; so the dataset covers the perturbations evaluation will throw at us. Stage
+          two rolls the oracle through Gazebo, recording rosbags and scores. Stage three filters for
+          successful episodes and converts them into a LeRobot dataset, finite-differencing the
+          oracle's pose commands into the same 6-DOF twist action space the policy will emit. Stage
+          four fine-tunes SmolVLA and sends it back through evaluation. Then iterate.
+        </p>
+        <div class="highlight">
+          <p class="mono highlight-label">&gt; key insight</p>
+          <p>
+            The SC connector trial scored near zero for every policy, and the reason turned out to be
+            the simulator itself: the SC plug's keying tabs collide with 3&nbsp;mm-wide interior port
+            geometry, so full insertion is physically impossible &mdash; even the ground-truth oracle
+            caps out around 40 points. A single &ldquo;full insertion&rdquo; filter threshold was
+            therefore discarding 100% of SC demonstrations. Switching to a per-archetype threshold
+            (SC&nbsp;&ge;&nbsp;35, SFP&nbsp;&ge;&nbsp;75) let partial-insertion SC demos into the
+            dataset &mdash; partial demos teach the policy to <em>engage</em> instead of hover &mdash;
+            and lifted the SC trial by 56% without hurting SFP.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================== Results ============================== -->
+    <section class="container" id="results" data-reveal>
+      <div class="section-head">
+        <span class="mono section-num">04 / results</span>
+        <h2>Results</h2>
+        <span class="rule" aria-hidden="true"></span>
+      </div>
+      <div class="prose">
+        <figure class="diagram" data-reveal>
+          <img src="images/aic-results.svg"
+            alt="Bar chart: total score rises from 38.2 for the ACT baseline through 69.8 and 95.3 for SmolVLA v3.1 and v4 to 110.3 for v6, against a dashed CheatCode oracle ceiling of 244.3"
+            width="800" height="460" loading="lazy" decoding="async">
+          <figcaption class="mono">each version is a dataset or training change, scanned across checkpoints</figcaption>
+        </figure>
+        <p>
+          The final dataset was 203 episodes (53,611 frames): SFP demonstrations, a slice targeting
+          the hardest port, and 20 partial-insertion SC demos admitted by the per-archetype filter.
+          Every model was scanned across training checkpoints before judging &mdash; the best run
+          peaked at 50k steps and measurably overtrained by 60k. The negative results were kept on
+          the books too: default image augmentation regressed every checkpoint (too aggressive for a
+          sub-centimeter task), and three attempts at hand-coded descent overrides all scored worse
+          than the pure learned policy &mdash; the remaining gap is lateral precision, not descent
+          timing. Along the way: compressed-camera republishing cut per-trial bags from 7.4&nbsp;GB
+          to 0.75&nbsp;GB, and a host/container launch fix took SC data collection from zero usable
+          episodes to 18 in one sweep.
+        </p>
+      </div>
+    </section>
+
+    <!-- ============================== Team ============================== -->
+    <section class="container" id="team" data-reveal>
+      <div class="section-head">
+        <span class="mono section-num">05 / team</span>
+        <h2>Team</h2>
+        <span class="rule" aria-hidden="true"></span>
+      </div>
+      <div class="prose">
+        <dl class="edu mono">
+          <div>
+            <dt>Tyler Johnson</dt>
+            <dd>lead &mdash; trial randomization framework, C++ engine fixes, evaluation orchestration,
+              and the fine-tuning experiment campaign from baseline to the 110.3 best</dd>
+          </div>
+          <div>
+            <dt>Abhijit Makhal</dt>
+            <dd>the four-stage data-collection pipeline (config generation, rollout orchestration,
+              LeRobot conversion) and the host&harr;container integration debugging</dd>
+          </div>
+          <div>
+            <dt>Amrit Saini</dt>
+            <dd>SmolVLA and Pi0 inference policies and the model training workflow the fine-tuning
+              campaign was built on</dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p class="mono">
+        &copy; <span id="year">2026</span> Tyler Johnson &middot;
+        <a href="https://github.com/johnsonTyler0511/johnsonTyler0511.github.io" target="_blank"
+          rel="noopener">source</a>
+      </p>
+    </div>
+  </footer>
+</body>
+
+</html>

--- a/css/main.css
+++ b/css/main.css
@@ -4,7 +4,7 @@
    1. tokens  2. reset  3. background texture  4. utilities
    5. header  6. section heads  7. hero  8. about  9. timeline
    10. projects  11. chips/skills  12. contact  13. footer
-   14. reveal animation  15. media queries
+   14. reveal animation  15. project detail page  16. media queries
    ============================================================ */
 
 /* ===== 1. tokens ===== */
@@ -619,7 +619,59 @@ html.js [data-reveal].is-visible {
   transform: none;
 }
 
-/* ===== 15. media queries ===== */
+/* ===== 15. project detail page ===== */
+.project-hero {
+  padding-block: clamp(3rem, 8vh, 5rem) 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.project-hero h1 {
+  font-size: var(--step-2);
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+.project-lede {
+  max-width: 46em;
+  font-size: var(--step-1);
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+.project-lede strong {
+  color: var(--text);
+}
+
+.prose {
+  max-width: 62em;
+  display: grid;
+  gap: 1rem;
+}
+
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--accent);
+}
+
+figure.diagram {
+  margin-block: 0.5rem 1rem;
+}
+
+figure.diagram img {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+figure.diagram figcaption {
+  margin-top: 0.6rem;
+  color: var(--text-muted);
+}
+
+/* ===== 16. media queries ===== */
 @media (min-width: 768px) {
   .about-grid {
     grid-template-columns: 280px 1fr;

--- a/images/aic-pipeline.svg
+++ b/images/aic-pipeline.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" width="800" height="500" role="img"
+  aria-label="Four-stage imitation learning pipeline: generate configs, oracle rollouts, filter and convert, fine-tune and evaluate, iterating in a loop">
+  <style>
+    .bg { fill: #0a0e12; }
+    .box { fill: #10161d; stroke: #1d2733; stroke-width: 1; rx: 8; }
+    .num { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #4ade80; letter-spacing: 0.08em; }
+    .title { font: 600 19px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #dce3ea; }
+    .sub { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #8b9bab; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.08em; }
+    .arrow { stroke: #16a34a; stroke-width: 2; fill: none; }
+    .arrowhead { fill: #16a34a; }
+    .looplabel { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.06em; }
+  </style>
+
+  <rect class="bg" x="0" y="0" width="800" height="500"/>
+
+  <text class="head" x="40" y="44">IMITATION LEARNING DATA PIPELINE</text>
+
+  <!-- markers -->
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" class="arrowhead"/>
+    </marker>
+  </defs>
+
+  <!-- Stage 1: top-left -->
+  <rect class="box" x="40" y="75" width="330" height="130" rx="8"/>
+  <text class="num" x="64" y="108">01 / GENERATE CONFIGS</text>
+  <text class="title" x="64" y="136">Randomized trials</text>
+  <text class="sub" x="64" y="161">pose noise · impedance · force</text>
+  <text class="sub" x="64" y="182">disturbances · SFP + SC archetypes</text>
+
+  <!-- Stage 2: top-right -->
+  <rect class="box" x="430" y="75" width="330" height="130" rx="8"/>
+  <text class="num" x="454" y="108">02 / ORACLE ROLLOUTS</text>
+  <text class="title" x="454" y="136">CheatCode in Gazebo</text>
+  <text class="sub" x="454" y="161">ground-truth TF policy drives</text>
+  <text class="sub" x="454" y="182">the UR5e &#8594; rosbags + scores</text>
+
+  <!-- Stage 3: bottom-right -->
+  <rect class="box" x="430" y="285" width="330" height="130" rx="8"/>
+  <text class="num" x="454" y="318">03 / FILTER + CONVERT</text>
+  <text class="title" x="454" y="346">LeRobot dataset</text>
+  <text class="sub" x="454" y="371">per-archetype tier-3 filter</text>
+  <text class="sub" x="454" y="392">(SC &#8805; 35, SFP &#8805; 75) &#8594; 6-DOF twists</text>
+
+  <!-- Stage 4: bottom-left -->
+  <rect class="box" x="40" y="285" width="330" height="130" rx="8"/>
+  <text class="num" x="64" y="318">04 / FINE-TUNE + EVAL</text>
+  <text class="title" x="64" y="346">SmolVLA policy</text>
+  <text class="sub" x="64" y="371">fine-tune VLA &#8594; evaluate via the</text>
+  <text class="sub" x="64" y="392">/insert_cable action &#8594; 110.3 best</text>
+
+  <!-- arrows: 1 -> 2 -> 3 -> 4 -> loop back to 1 -->
+  <line class="arrow" x1="370" y1="140" x2="422" y2="140" marker-end="url(#ah)"/>
+  <line class="arrow" x1="595" y1="205" x2="595" y2="277" marker-end="url(#ah)"/>
+  <line class="arrow" x1="430" y1="350" x2="378" y2="350" marker-end="url(#ah)"/>
+  <path class="arrow" d="M 205 285 L 205 245 L 205 213" marker-end="url(#ah)"/>
+  <text class="looplabel" x="222" y="253">iterate</text>
+</svg>

--- a/images/aic-results.svg
+++ b/images/aic-results.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 460" width="800" height="460" role="img"
+  aria-label="Bar chart of policy score progression: ACT baseline 38.2, SmolVLA v3.1 69.8, v4 95.3, v6 110.3, against a CheatCode oracle ceiling of 244.3">
+  <style>
+    .bg { fill: #0a0e12; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.08em; }
+    .subtitle { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #8b9bab; }
+    .grid { stroke: #1d2733; stroke-width: 1; }
+    .tick { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; }
+    .bar { fill: #16a34a; }
+    .val { font: 400 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; }
+    .val-hero { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #dce3ea; }
+    .xlab { font: 600 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #dce3ea; }
+    .xsub { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; }
+    .ref { stroke: #8b9bab; stroke-width: 1.5; stroke-dasharray: 6 5; }
+    .reflab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.04em; }
+  </style>
+
+  <rect class="bg" x="0" y="0" width="800" height="460"/>
+
+  <text class="head" x="40" y="36">POLICY SCORE PROGRESSION</text>
+  <text class="subtitle" x="40" y="58">Total score on the 3-trial eval config (SFP &#215;2, SC &#215;1) &#8212; higher is better</text>
+
+  <!-- gridlines + y ticks (0..250) -->
+  <line class="grid" x1="70" y1="390" x2="760" y2="390"/>
+  <line class="grid" x1="70" y1="328" x2="760" y2="328"/>
+  <line class="grid" x1="70" y1="266" x2="760" y2="266"/>
+  <line class="grid" x1="70" y1="204" x2="760" y2="204"/>
+  <line class="grid" x1="70" y1="142" x2="760" y2="142"/>
+  <line class="grid" x1="70" y1="80" x2="760" y2="80"/>
+  <text class="tick" x="58" y="394" text-anchor="end">0</text>
+  <text class="tick" x="58" y="332" text-anchor="end">50</text>
+  <text class="tick" x="58" y="270" text-anchor="end">100</text>
+  <text class="tick" x="58" y="208" text-anchor="end">150</text>
+  <text class="tick" x="58" y="146" text-anchor="end">200</text>
+  <text class="tick" x="58" y="84" text-anchor="end">250</text>
+
+  <!-- oracle reference line: 244.27 -->
+  <line class="ref" x1="70" y1="87" x2="760" y2="87"/>
+  <text class="reflab" x="760" y="103" text-anchor="end">cheatcode oracle &#183; 244.3</text>
+
+  <!-- bars: 24px wide, 4px rounded data-end, square baseline -->
+  <path class="bar" d="M 144 390 L 144 346.6 Q 144 342.6 148 342.6 L 164 342.6 Q 168 342.6 168 346.6 L 168 390 Z"/>
+  <path class="bar" d="M 317 390 L 317 307.5 Q 317 303.5 321 303.5 L 337 303.5 Q 341 303.5 341 307.5 L 341 390 Z"/>
+  <path class="bar" d="M 489 390 L 489 275.8 Q 489 271.8 493 271.8 L 509 271.8 Q 513 271.8 513 275.8 L 513 390 Z"/>
+  <path class="bar" d="M 662 390 L 662 257.2 Q 662 253.2 666 253.2 L 682 253.2 Q 686 253.2 686 257.2 L 686 390 Z"/>
+
+  <!-- value labels at bar caps -->
+  <text class="val" x="156" y="332" text-anchor="middle">38.2</text>
+  <text class="val" x="329" y="293" text-anchor="middle">69.8</text>
+  <text class="val" x="501" y="261" text-anchor="middle">95.3</text>
+  <text class="val-hero" x="674" y="242" text-anchor="middle">110.3</text>
+
+  <!-- x category labels -->
+  <text class="xlab" x="156" y="416" text-anchor="middle">ACT</text>
+  <text class="xsub" x="156" y="436" text-anchor="middle">baseline</text>
+  <text class="xlab" x="329" y="416" text-anchor="middle">SmolVLA v3.1</text>
+  <text class="xsub" x="329" y="436" text-anchor="middle">SFP-only data</text>
+  <text class="xlab" x="501" y="416" text-anchor="middle">SmolVLA v4</text>
+  <text class="xsub" x="501" y="436" text-anchor="middle">@40k steps</text>
+  <text class="xlab" x="674" y="416" text-anchor="middle">SmolVLA v6</text>
+  <text class="xsub" x="674" y="436" text-anchor="middle">@50k &#183; +SC demos</text>
+</svg>

--- a/images/aic-system.svg
+++ b/images/aic-system.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450" role="img"
+  aria-label="System architecture: the organizers' C++ evaluation stack (engine, controller, adapter, Gazebo) exchanges observations and twist commands with the team's Python participant model over the /insert_cable ROS 2 action">
+  <style>
+    .bg { fill: #0a0e12; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.08em; }
+    .container-eval { fill: none; stroke: #3b82f6; stroke-width: 1.5; }
+    .container-team { fill: none; stroke: #16a34a; stroke-width: 1.5; }
+    .grouplab-eval { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #3b82f6; letter-spacing: 0.08em; }
+    .grouplab-team { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #16a34a; letter-spacing: 0.08em; }
+    .box { fill: #10161d; stroke: #1d2733; stroke-width: 1; }
+    .title { font: 600 16px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #dce3ea; }
+    .sub { font: 400 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #8b9bab; }
+    .arrow-eval { stroke: #3b82f6; stroke-width: 2; fill: none; }
+    .arrow-team { stroke: #16a34a; stroke-width: 2; fill: none; }
+    .flowlab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8b9bab; letter-spacing: 0.04em; }
+    .action { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #dce3ea; letter-spacing: 0.04em; }
+  </style>
+
+  <rect class="bg" x="0" y="0" width="800" height="450"/>
+
+  <text class="head" x="40" y="40">SYSTEM ARCHITECTURE &#183; ROS 2 KILTED &#183; ZENOH RMW</text>
+
+  <defs>
+    <marker id="ah-eval" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#3b82f6"/>
+    </marker>
+    <marker id="ah-team" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#16a34a"/>
+    </marker>
+  </defs>
+
+  <!-- evaluation stack (organizers, C++) -->
+  <rect class="container-eval" x="40" y="66" width="300" height="344" rx="10"/>
+  <text class="grouplab-eval" x="64" y="94">EVAL STACK &#183; C++ &#183; ORGANIZERS</text>
+
+  <rect class="box" x="64" y="110" width="252" height="58" rx="6"/>
+  <text class="title" x="80" y="134">aic_engine</text>
+  <text class="sub" x="80" y="154">trial orchestration &#183; scoring</text>
+
+  <rect class="box" x="64" y="178" width="252" height="58" rx="6"/>
+  <text class="title" x="80" y="202">aic_controller</text>
+  <text class="sub" x="80" y="222">impedance / force control</text>
+
+  <rect class="box" x="64" y="246" width="252" height="58" rx="6"/>
+  <text class="title" x="80" y="270">aic_adapter</text>
+  <text class="sub" x="80" y="290">sensor fusion</text>
+
+  <rect class="box" x="64" y="314" width="252" height="58" rx="6"/>
+  <text class="title" x="80" y="338">Gazebo</text>
+  <text class="sub" x="80" y="358">physics sim &#183; UR5e + task board</text>
+
+  <!-- participant model (team, Python) -->
+  <rect class="container-team" x="500" y="66" width="260" height="344" rx="10"/>
+  <text class="grouplab-team" x="524" y="94">PARTICIPANT MODEL &#183; PYTHON</text>
+
+  <rect class="box" x="524" y="118" width="212" height="94" rx="6"/>
+  <text class="title" x="540" y="146">aic_model</text>
+  <text class="sub" x="540" y="168">ROS 2 lifecycle node</text>
+  <text class="sub" x="540" y="188">dynamically loads a Policy</text>
+
+  <rect class="box" x="524" y="238" width="212" height="116" rx="6"/>
+  <text class="title" x="540" y="266">RunSmolVLA</text>
+  <text class="sub" x="540" y="288">fine-tuned SmolVLA policy</text>
+  <text class="sub" x="540" y="308">images + robot state in,</text>
+  <text class="sub" x="540" y="328">Cartesian twist out</text>
+
+  <!-- interface -->
+  <text class="action" x="420" y="130" text-anchor="middle">/insert_cable</text>
+  <text class="flowlab" x="420" y="150" text-anchor="middle">ROS 2 action</text>
+
+  <!-- observations: eval -> model -->
+  <line class="arrow-eval" x1="340" y1="205" x2="492" y2="205" marker-end="url(#ah-eval)"/>
+  <text class="flowlab" x="420" y="195" text-anchor="middle">camera &#183; wrench</text>
+  <text class="flowlab" x="420" y="225" text-anchor="middle">joint states</text>
+
+  <!-- commands: model -> eval -->
+  <line class="arrow-team" x1="500" y1="300" x2="348" y2="300" marker-end="url(#ah-team)"/>
+  <text class="flowlab" x="420" y="290" text-anchor="middle">6-DOF cartesian</text>
+  <text class="flowlab" x="420" y="320" text-anchor="middle">twist commands</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -239,6 +239,24 @@
 
         <li class="card" data-reveal>
           <div class="card-media">
+            <img src="images/aic-pipeline.svg"
+              alt="Four-stage imitation learning pipeline from randomized trial generation through oracle rollouts and dataset conversion to SmolVLA fine-tuning"
+              width="800" height="500" loading="lazy" decoding="async">
+          </div>
+          <div class="card-body">
+            <h3><a href="aic.html">AIC Connector Insertion</a> <span class="mono card-note">private repo</span></h3>
+            <p>
+              Team entry to Intrinsic's AI for Industry Challenge: a fine-tuned SmolVLA
+              vision-language-action policy teaching a simulated UR5e to insert fiber-optic
+              connectors — nearly 3&times; the provided baseline (38.2 &rarr; 110.3). Built with
+              Abhijit Makhal and Amrit Saini; full write-up inside.
+            </p>
+            <p class="mono tech-tags">ROS 2 &middot; LeRobot &middot; SmolVLA &middot; Gazebo &middot; Python &middot; C++</p>
+          </div>
+        </li>
+
+        <li class="card" data-reveal>
+          <div class="card-media">
             <img src="images/OrbSlam.jpeg" alt="ORB-SLAM2 feature tracking on a KITTI urban driving scene"
               width="320" height="254" loading="lazy" decoding="async">
           </div>


### PR DESCRIPTION
## What

Adds the team's **AI for Industry Challenge** (Intrinsic) work as a new portfolio project — the SmolVLA imitation-learning entry for robotic fiber-optic connector insertion built with Abhijit Makhal and Amrit Saini.

- **`index.html`** — new project card at the top of the grid, following the existing card template (pipeline-diagram thumbnail, `private repo` note, tech tags), linking to the detail page.
- **`aic.html`** — the site's first project detail page: overview, system architecture, data & training pipeline (including the SC geometry-ceiling investigation and per-archetype filter insight), results with honest negative results, and per-person team credits.
- **`images/aic-system.svg`, `images/aic-pipeline.svg`, `images/aic-results.svg`** — three hand-authored SVG diagrams styled to the site's palette (colors validated for contrast and colorblind separation on the dark surface).
- **`css/main.css`** — a small new "project detail page" section reusing the existing design tokens; no changes to existing rules.

## Notes

- Content is sourced from the private `aic_clone` repo's PR history (PRs #1–#11); the page states the repo is private and publishes only the narrative, architecture, and score numbers — no code or internals.
- Verified locally with `python3 -m http.server`: all pages and image paths resolve, card matches the existing grid style, detail page renders end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)