### PR TITLE
Restyle: ocean-descent theme + normal capitalization

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>404 — Tyler Johnson</title>
   <meta name="robots" content="noindex">
-  <meta name="theme-color" content="#1e262b">
+  <meta name="theme-color" content="#0d4f6e">
   <link rel="icon" href="/favicon.ico" sizes="32x32">
   <link rel="icon" href="/images/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/main.css">

--- a/aic.html
+++ b/aic.html
@@ -9,7 +9,7 @@
   <meta name="description"
     content="Team entry to Intrinsic's AI for Industry Challenge: a fine-tuned SmolVLA vision-language-action policy for robotic fiber-optic connector insertion, nearly tripling the provided baseline.">
   <link rel="canonical" href="https://johnsontyler0511.github.io/aic.html">
-  <meta name="theme-color" content="#1e262b">
+  <meta name="theme-color" content="#0d4f6e">
 
   <meta property="og:title" content="AIC Connector Insertion — Tyler Johnson">
   <meta property="og:description"
@@ -33,11 +33,11 @@
       <a class="brand" href="index.html"><span class="brand-mark"><svg viewBox="0 0 16 16" width="14" height="14"
             fill="none" stroke-linecap="round" aria-hidden="true">
             <circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.4" />
-            <circle cx="8" cy="8" r="4.8" stroke="#7fbbb3" stroke-width="1.1" opacity="0.8" />
-            <circle cx="8" cy="8" r="7.2" stroke="#7fbbb3" stroke-width="1" opacity="0.45" />
+            <circle cx="8" cy="8" r="4.8" stroke="#6fd6c3" stroke-width="1.1" opacity="0.8" />
+            <circle cx="8" cy="8" r="7.2" stroke="#6fd6c3" stroke-width="1" opacity="0.45" />
           </svg></span> tyler.johnson</a>
       <ul class="nav-links">
-        <li><a href="index.html#projects">&larr; back to projects</a></li>
+        <li><a href="index.html#projects">&larr; Back to projects</a></li>
       </ul>
     </nav>
   </header>
@@ -46,8 +46,8 @@
 
     <!-- ============================== Hero ============================== -->
     <section class="project-hero container">
-      <p class="mono eyebrow">project &middot; imitation learning &middot; robot manipulation</p>
-      <h1>AIC Connector Insertion <span class="mono card-note">private repo &mdash; code cannot be shared</span></h1>
+      <p class="mono eyebrow">Project &middot; Imitation Learning &middot; Robot Manipulation</p>
+      <h1>AIC Connector Insertion <span class="mono card-note">Private repo &mdash; code cannot be shared</span></h1>
       <p class="project-lede">
         Team entry to Intrinsic's <strong>AI for Industry Challenge</strong>: teaching a simulated
         UR5e to plug fiber-optic connectors into a networking task board with a fine-tuned
@@ -61,7 +61,7 @@
     <!-- ============================== Overview ============================== -->
     <section class="container" id="overview" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">01 / overview</span>
+        <span class="mono section-num">01 / Overview</span>
         <h2>Overview</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -87,7 +87,7 @@
     <!-- ============================== System ============================== -->
     <section class="container" id="system" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">02 / system</span>
+        <span class="mono section-num">02 / System</span>
         <h2>System</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -96,7 +96,7 @@
           <img src="images/aic-system.svg"
             alt="System architecture: the organizers' C++ evaluation stack (aic_engine, aic_controller, aic_adapter, Gazebo) exchanges camera, wrench, and joint-state observations and 6-DOF twist commands with the team's Python participant model over the /insert_cable ROS 2 action"
             width="800" height="450" loading="lazy" decoding="async">
-          <figcaption class="mono">two components, one action interface</figcaption>
+          <figcaption class="mono">Two components, one action interface</figcaption>
         </figure>
         <p>
           Everything meets at one boundary. The evaluation side owns the physics: an engine that
@@ -114,7 +114,7 @@
     <!-- ============================== Pipeline ============================== -->
     <section class="container" id="pipeline" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">03 / data pipeline</span>
+        <span class="mono section-num">03 / Data Pipeline</span>
         <h2>Data &amp; Training Pipeline</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -123,7 +123,7 @@
           <img src="images/aic-pipeline.svg"
             alt="Four-stage imitation learning loop: generate randomized trial configs, roll out the CheatCode oracle in Gazebo to produce rosbags and scores, filter and convert successes into a LeRobot dataset, fine-tune and evaluate SmolVLA, then iterate"
             width="800" height="500" loading="lazy" decoding="async">
-          <figcaption class="mono">the imitation-learning loop</figcaption>
+          <figcaption class="mono">The imitation-learning loop</figcaption>
         </figure>
         <p>
           Demonstrations come from <em>CheatCode</em>, an oracle policy that reads ground-truth
@@ -136,7 +136,7 @@
           four fine-tunes SmolVLA and sends it back through evaluation. Then iterate.
         </p>
         <div class="highlight">
-          <p class="mono highlight-label">key insight</p>
+          <p class="mono highlight-label">Key Insight</p>
           <p>
             The SC connector trial scored near zero for every policy, and the reason turned out to be
             the simulator itself: the SC plug's keying tabs collide with 3&nbsp;mm-wide interior port
@@ -154,7 +154,7 @@
     <!-- ============================== Results ============================== -->
     <section class="container" id="results" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">04 / results</span>
+        <span class="mono section-num">04 / Results</span>
         <h2>Results</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -163,7 +163,7 @@
           <img src="images/aic-results.svg"
             alt="Bar chart: total score rises from 38.2 for the ACT baseline through 69.8 and 95.3 for SmolVLA v3.1 and v4 to 110.3 for v6, against a dashed CheatCode oracle ceiling of 244.3"
             width="800" height="460" loading="lazy" decoding="async">
-          <figcaption class="mono">each version is a dataset or training change, scanned across checkpoints</figcaption>
+          <figcaption class="mono">Each version is a dataset or training change, scanned across checkpoints</figcaption>
         </figure>
         <p>
           The final dataset was 203 episodes (53,611 frames): SFP demonstrations, a slice targeting
@@ -183,7 +183,7 @@
     <!-- ============================== Team ============================== -->
     <section class="container" id="team" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">05 / team</span>
+        <span class="mono section-num">05 / Team</span>
         <h2>Team</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -191,12 +191,12 @@
         <dl class="edu mono">
           <div>
             <dt>Tyler Johnson</dt>
-            <dd>lead &mdash; trial randomization framework, C++ engine fixes, evaluation orchestration,
+            <dd>Lead &mdash; trial randomization framework, C++ engine fixes, evaluation orchestration,
               and the fine-tuning experiment campaign from baseline to the 110.3 best</dd>
           </div>
           <div>
             <dt>Abhijit Makhal</dt>
-            <dd>the four-stage data-collection pipeline (config generation, rollout orchestration,
+            <dd>The four-stage data-collection pipeline (config generation, rollout orchestration,
               LeRobot conversion) and the host&harr;container integration debugging</dd>
           </div>
           <div>
@@ -215,7 +215,7 @@
       <p class="mono">
         &copy; <span id="year">2026</span> Tyler Johnson &middot;
         <a href="https://github.com/johnsonTyler0511/johnsonTyler0511.github.io" target="_blank"
-          rel="noopener">source</a>
+          rel="noopener">Source</a>
       </p>
     </div>
   </footer>

--- a/css/main.css
+++ b/css/main.css
@@ -1,33 +1,34 @@
 /* ============================================================
    tyler.johnson — portfolio
    hand-written css, no dependencies. layers:
-   1. tokens  2. reset  3. topo/horizon texture  4. utilities
+   1. tokens  2. reset  3. ocean layers  4. utilities
    5. header  6. section heads  7. hero  8. about  9. timeline
    10. projects  11. chips/skills  12. contact  13. footer
    14. reveal animation  15. project detail page  16. media queries
 
-   palette: "forest lake at dusk" — everforest terminal colors
-   meeting an alpine-lake-at-sunset wallpaper. deep blue-green
-   water, parchment text, teal / amber / coral accents.
+   palette: "ocean descent" — sunlit surface water at the top of
+   the page fading to a bioluminescent abyss at the bottom.
+   sea-foam text, seafoam / cyan / coral accents.
    ============================================================ */
 
 /* ===== 1. tokens ===== */
 :root {
-  --bg: #1e262b;
-  /* deep lake blue-green */
-  --bg-raised: #2b3639;
-  --border: #3a464a;
-  --text: #d8cdb8;
-  /* warm parchment */
-  --text-muted: #9aa79d;
-  --accent: #7fbbb3;
-  /* teal — links, buttons, focus */
-  --accent-2: #dbbc7f;
-  /* amber — labels, eyebrows */
-  --pop: #e08f80;
-  /* coral — badges, highlights */
-  --accent-glow: rgba(127, 187, 179, 0.08);
-  --pop-glow: rgba(224, 143, 128, 0.07);
+  --bg: #062940;
+  /* solid deep-water fallback (media wells, fills) */
+  --bg-raised: rgba(9, 43, 66, 0.55);
+  /* translucent so the depth gradient shows through cards */
+  --border: #1f4d68;
+  --text: #e6f1ec;
+  /* sea-foam white */
+  --text-muted: #9fc3cd;
+  --accent: #6fd6c3;
+  /* seafoam — links, buttons, focus */
+  --accent-2: #8fd3f4;
+  /* sunlit-water cyan — labels, eyebrows */
+  --pop: #ff9b85;
+  /* bright coral — badges, highlights */
+  --accent-glow: rgba(111, 214, 195, 0.10);
+  --pop-glow: rgba(255, 155, 133, 0.08);
 
   --font-body: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
   --font-mono: ui-monospace, "JetBrains Mono", "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
@@ -52,6 +53,10 @@
 
 html {
   color-scheme: dark;
+  /* anchors the abyss particle layer and clips the wave drift overdraw */
+  position: relative;
+  min-height: 100%;
+  overflow-x: clip;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -65,7 +70,19 @@ section[id] {
 }
 
 body {
-  background: var(--bg);
+  /* the descent: % stops span the document, so every page runs
+     surface → abyss regardless of its height. html stays
+     background-less so this propagates to the canvas and the
+     negative-z decorative layers paint above it. */
+  background: linear-gradient(to bottom,
+      #0d4f6e 0%,
+      #0a3f5c 18%,
+      #072f49 45%,
+      #041f34 70%,
+      #020f1c 90%,
+      #01070e 100%) #01070e;
+  position: relative;
+  min-height: 100vh;
   color: var(--text);
   font-family: var(--font-body);
   font-size: var(--step-0);
@@ -101,32 +118,98 @@ ol {
   padding: 0;
 }
 
-/* ===== 3. topo/horizon texture ===== */
-/* faint elevation contours — half trail map, half costmap.
-   stroke color is baked into the data uri (css vars can't reach it). */
+/* ===== 3. ocean layers ===== */
+/* all layers are document-anchored (absolute, not fixed) so the
+   surface scrolls away as you dive. stroke color is baked into the
+   wave data uri (css vars can't reach it). */
+
+/* surface waves — drift slowly sideways; the -640px left overdraw
+   is one tile width so the translateX loop never shows a gap */
 body::before {
   content: "";
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  top: 0;
+  left: -640px;
+  right: 0;
+  height: min(70vh, 34rem);
   z-index: -2;
   pointer-events: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='640' viewBox='0 0 640 640'%3E%3Cg fill='none' stroke='%237fbbb3' stroke-opacity='.07' stroke-width='1.2'%3E%3Cpath d='M245 190C245 215 228 232 200 234 172 236 156 214 158 188 160 164 176 148 202 148 226 148 245 166 245 190Z'/%3E%3Cpath d='M285 188C288 232 252 272 202 274 152 276 116 238 114 190 112 144 148 106 200 104 250 102 282 146 285 188Z'/%3E%3Cpath d='M325 185C332 248 288 310 204 314 122 318 76 262 74 192 72 124 124 68 202 64 278 60 318 124 325 185Z'/%3E%3Cpath d='M365 182C376 264 330 350 206 356 90 362 36 286 34 194 32 104 100 30 204 24 306 18 354 102 365 182Z'/%3E%3Cpath d='M515 470C515 490 501 504 480 505 459 506 445 491 446 469 447 449 461 436 481 436 500 436 515 451 515 470Z'/%3E%3Cpath d='M550 468C552 504 523 538 481 540 439 542 411 510 410 470 409 432 438 402 480 400 520 398 548 432 550 468Z'/%3E%3Cpath d='M585 466C590 518 552 572 483 575 415 578 376 532 375 472 374 414 416 368 481 365 544 362 580 414 585 466Z'/%3E%3C/g%3E%3C/svg%3E");
-  background-size: 640px 640px;
-  -webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 0%, black 30%, transparent 75%);
-  mask-image: radial-gradient(ellipse 90% 70% at 50% 0%, black 30%, transparent 75%);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='640' height='200' viewBox='0 0 640 200'%3E%3Cg fill='none' stroke='%236fd6c3' stroke-width='1.4'%3E%3Cpath stroke-opacity='.14' d='M0 40q40 -12 80 0t80 0t80 0t80 0t80 0t80 0t80 0'/%3E%3Cpath stroke-opacity='.10' d='M0 105q64 -16 128 0t128 0t128 0t128 0'/%3E%3Cpath stroke-opacity='.07' d='M0 165q80 -18 160 0t160 0t160 0'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 640px 200px;
+  -webkit-mask-image: linear-gradient(to bottom, black 30%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 30%, transparent 100%);
+  animation: wave-drift 80s linear infinite;
 }
 
-/* dusk horizon — warm sunset band fading into the lake */
+/* sunlight — a soft glow at the surface and faint diagonal god-rays
+   shafting down into the upper water */
 body::after {
   content: "";
-  position: fixed;
-  inset: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 120vh;
   z-index: -3;
   pointer-events: none;
-  background: linear-gradient(to bottom,
-      var(--pop-glow),
-      rgba(219, 188, 127, 0.04) 16%,
-      transparent 42%);
+  background:
+    radial-gradient(110% 55% at 50% -12%, rgba(125, 216, 255, 0.12), transparent 62%),
+    repeating-linear-gradient(101deg,
+      transparent 0 140px,
+      rgba(140, 225, 255, 0.05) 170px 210px,
+      transparent 240px 380px);
+  -webkit-mask-image: linear-gradient(to bottom, black 25%, transparent 95%);
+  mask-image: linear-gradient(to bottom, black 25%, transparent 95%);
+  animation: ray-shimmer 14s ease-in-out infinite alternate;
+}
+
+/* bioluminescence — tiny drifting motes that only live in the deep;
+   bottom-anchored so they sit in the abyss on any page length */
+html::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: min(160vh, 100%);
+  z-index: -2;
+  pointer-events: none;
+  background-image:
+    radial-gradient(2px 2px at 20% 30%, rgba(139, 241, 255, 0.55), transparent 60%),
+    radial-gradient(1.5px 1.5px at 70% 65%, rgba(150, 255, 216, 0.40), transparent 60%),
+    radial-gradient(2.5px 2.5px at 45% 85%, rgba(172, 160, 255, 0.35), transparent 60%),
+    radial-gradient(1.5px 1.5px at 85% 20%, rgba(139, 241, 255, 0.40), transparent 60%),
+    radial-gradient(2px 2px at 10% 70%, rgba(150, 255, 216, 0.35), transparent 60%);
+  background-size: 520px 520px, 460px 460px, 610px 610px, 380px 380px, 550px 550px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 55%);
+  mask-image: linear-gradient(to bottom, transparent 0%, black 55%);
+  animation: plankton-bob 20s ease-in-out infinite alternate;
+}
+
+@keyframes wave-drift {
+  to {
+    transform: translateX(640px);
+  }
+}
+
+@keyframes ray-shimmer {
+  from {
+    opacity: 0.55;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes plankton-bob {
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-14px);
+  }
 }
 
 /* ===== 4. utilities ===== */
@@ -175,7 +258,7 @@ body::after {
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(30, 38, 43, 0.85);
+  background: rgba(3, 21, 34, 0.72);
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
@@ -443,7 +526,7 @@ section {
 .highlight {
   margin-block: 1rem;
   padding: 1rem 1.25rem;
-  background: rgba(224, 143, 128, 0.06);
+  background: rgba(255, 155, 133, 0.06);
   border-left: 2px solid var(--pop);
   border-radius: 0 6px 6px 0;
   max-width: 62em;
@@ -475,6 +558,8 @@ section {
   display: flex;
   flex-direction: column;
   background: var(--bg-raised);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
   border: 1px solid var(--border);
   border-radius: 8px;
   overflow: hidden;
@@ -618,7 +703,6 @@ section {
 
 .site-footer .mono {
   color: var(--text-muted);
-  text-transform: none;
   letter-spacing: 0.03em;
 }
 

--- a/images/aic-pipeline.svg
+++ b/images/aic-pipeline.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500" width="800" height="500" role="img"
   aria-label="Four-stage imitation learning pipeline: generate configs, oracle rollouts, filter and convert, fine-tune and evaluate, iterating in a loop">
   <style>
-    .bg { fill: #1e262b; }
-    .box { fill: #2b3639; stroke: #3a464a; stroke-width: 1; rx: 8; }
-    .num { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #dbbc7f; letter-spacing: 0.08em; }
-    .title { font: 600 19px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #d8cdb8; }
-    .sub { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9aa79d; }
-    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.08em; }
-    .arrow { stroke: #7fbbb3; stroke-width: 2; fill: none; }
-    .arrowhead { fill: #7fbbb3; }
-    .looplabel { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.06em; }
+    .bg { fill: #062940; }
+    .box { fill: #0a3450; stroke: #1f4d68; stroke-width: 1; rx: 8; }
+    .num { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8fd3f4; letter-spacing: 0.08em; }
+    .title { font: 600 19px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #e6f1ec; }
+    .sub { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9fc3cd; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.08em; }
+    .arrow { stroke: #6fd6c3; stroke-width: 2; fill: none; }
+    .arrowhead { fill: #6fd6c3; }
+    .looplabel { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.06em; }
   </style>
 
   <rect class="bg" x="0" y="0" width="800" height="500"/>

--- a/images/aic-results.svg
+++ b/images/aic-results.svg
@@ -1,18 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 460" width="800" height="460" role="img"
   aria-label="Bar chart of policy score progression: ACT baseline 38.2, SmolVLA v3.1 69.8, v4 95.3, v6 110.3, against a CheatCode oracle ceiling of 244.3">
   <style>
-    .bg { fill: #1e262b; }
-    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.08em; }
-    .subtitle { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9aa79d; }
-    .grid { stroke: #3a464a; stroke-width: 1; }
-    .tick { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; }
-    .bar { fill: #7fbbb3; }
-    .val { font: 400 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; }
-    .val-hero { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #d8cdb8; }
-    .xlab { font: 600 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #d8cdb8; }
-    .xsub { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; }
-    .ref { stroke: #9aa79d; stroke-width: 1.5; stroke-dasharray: 6 5; }
-    .reflab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.04em; }
+    .bg { fill: #062940; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.08em; }
+    .subtitle { font: 400 14px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9fc3cd; }
+    .grid { stroke: #1f4d68; stroke-width: 1; }
+    .tick { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; }
+    .bar { fill: #6fd6c3; }
+    .val { font: 400 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; }
+    .val-hero { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #e6f1ec; }
+    .xlab { font: 600 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #e6f1ec; }
+    .xsub { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; }
+    .ref { stroke: #9fc3cd; stroke-width: 1.5; stroke-dasharray: 6 5; }
+    .reflab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.04em; }
   </style>
 
   <rect class="bg" x="0" y="0" width="800" height="460"/>

--- a/images/aic-system.svg
+++ b/images/aic-system.svg
@@ -1,19 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450" role="img"
   aria-label="System architecture: the organizers' C++ evaluation stack (engine, controller, adapter, Gazebo) exchanges observations and twist commands with the team's Python participant model over the /insert_cable ROS 2 action">
   <style>
-    .bg { fill: #1e262b; }
-    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.08em; }
-    .container-eval { fill: none; stroke: #7fbbb3; stroke-width: 1.5; }
-    .container-team { fill: none; stroke: #dbbc7f; stroke-width: 1.5; }
-    .grouplab-eval { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #7fbbb3; letter-spacing: 0.08em; }
-    .grouplab-team { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #dbbc7f; letter-spacing: 0.08em; }
-    .box { fill: #2b3639; stroke: #3a464a; stroke-width: 1; }
-    .title { font: 600 16px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #d8cdb8; }
-    .sub { font: 400 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9aa79d; }
-    .arrow-eval { stroke: #7fbbb3; stroke-width: 2; fill: none; }
-    .arrow-team { stroke: #dbbc7f; stroke-width: 2; fill: none; }
-    .flowlab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9aa79d; letter-spacing: 0.04em; }
-    .action { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #d8cdb8; letter-spacing: 0.04em; }
+    .bg { fill: #062940; }
+    .head { font: 600 13px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.08em; }
+    .container-eval { fill: none; stroke: #6fd6c3; stroke-width: 1.5; }
+    .container-team { fill: none; stroke: #8fd3f4; stroke-width: 1.5; }
+    .grouplab-eval { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #6fd6c3; letter-spacing: 0.08em; }
+    .grouplab-team { font: 600 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #8fd3f4; letter-spacing: 0.08em; }
+    .box { fill: #0a3450; stroke: #1f4d68; stroke-width: 1; }
+    .title { font: 600 16px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #e6f1ec; }
+    .sub { font: 400 13px system-ui, -apple-system, "Segoe UI", sans-serif; fill: #9fc3cd; }
+    .arrow-eval { stroke: #6fd6c3; stroke-width: 2; fill: none; }
+    .arrow-team { stroke: #8fd3f4; stroke-width: 2; fill: none; }
+    .flowlab { font: 400 12px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #9fc3cd; letter-spacing: 0.04em; }
+    .action { font: 600 14px ui-monospace, "SF Mono", Menlo, Consolas, monospace; fill: #e6f1ec; letter-spacing: 0.04em; }
   </style>
 
   <rect class="bg" x="0" y="0" width="800" height="450"/>
@@ -22,10 +22,10 @@
 
   <defs>
     <marker id="ah-eval" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#7fbbb3"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#6fd6c3"/>
     </marker>
     <marker id="ah-team" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#dbbc7f"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8fd3f4"/>
     </marker>
   </defs>
 

--- a/images/favicon.svg
+++ b/images/favicon.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <rect width="64" height="64" rx="12" fill="#1e262b"/>
-  <rect x="1.5" y="1.5" width="61" height="61" rx="10.5" fill="none" stroke="#3a464a" stroke-width="3"/>
-  <g fill="none" stroke="#7fbbb3" stroke-opacity="0.22">
+  <rect width="64" height="64" rx="12" fill="#062940"/>
+  <rect x="1.5" y="1.5" width="61" height="61" rx="10.5" fill="none" stroke="#1f4d68" stroke-width="3"/>
+  <g fill="none" stroke="#6fd6c3" stroke-opacity="0.22">
     <circle cx="47" cy="15" r="9" stroke-width="1.6"/>
     <circle cx="47" cy="15" r="16" stroke-width="1.4"/>
     <circle cx="47" cy="15" r="23" stroke-width="1.2"/>
   </g>
-  <line x1="10" y1="53" x2="54" y2="53" stroke="#e08f80" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="10" y1="53" x2="54" y2="53" stroke="#ff9b85" stroke-width="2.5" stroke-linecap="round"/>
   <text x="32" y="44" text-anchor="middle" font-family="ui-monospace, Menlo, Consolas, monospace"
-    font-size="34" font-weight="700" fill="#7fbbb3">tj</text>
+    font-size="34" font-weight="700" fill="#6fd6c3">tj</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <meta name="description"
     content="Tyler Johnson is a senior robotics engineer in Boston specializing in motion planning, manipulation, and control — currently building Locus Array, fully autonomous fulfillment robots, at Locus Robotics.">
   <link rel="canonical" href="https://johnsontyler0511.github.io/">
-  <meta name="theme-color" content="#1e262b">
+  <meta name="theme-color" content="#0d4f6e">
 
   <meta property="og:title" content="Tyler Johnson — Senior Robotics Engineer">
   <meta property="og:description"
@@ -61,15 +61,15 @@
       <a class="brand" href="#top"><span class="brand-mark"><svg viewBox="0 0 16 16" width="14" height="14"
             fill="none" stroke-linecap="round" aria-hidden="true">
             <circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.4" />
-            <circle cx="8" cy="8" r="4.8" stroke="#7fbbb3" stroke-width="1.1" opacity="0.8" />
-            <circle cx="8" cy="8" r="7.2" stroke="#7fbbb3" stroke-width="1" opacity="0.45" />
+            <circle cx="8" cy="8" r="4.8" stroke="#6fd6c3" stroke-width="1.1" opacity="0.8" />
+            <circle cx="8" cy="8" r="7.2" stroke="#6fd6c3" stroke-width="1" opacity="0.45" />
           </svg></span> tyler.johnson</a>
       <ul class="nav-links">
-        <li><a href="#about">about</a></li>
-        <li><a href="#experience">experience</a></li>
-        <li><a href="#projects">projects</a></li>
-        <li><a href="#skills">skills</a></li>
-        <li><a href="#contact">contact</a></li>
+        <li><a href="#about">About</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#skills">Skills</a></li>
+        <li><a href="#contact">Contact</a></li>
       </ul>
     </nav>
   </header>
@@ -78,7 +78,7 @@
 
     <!-- ============================== Hero ============================== -->
     <section class="hero container" id="top">
-      <p class="mono eyebrow">senior robotics engineer · boston, ma</p>
+      <p class="mono eyebrow">Senior Robotics Engineer · Boston, MA</p>
       <h1>Tyler Johnson</h1>
       <p class="hero-tagline">
         I build the software that makes industrial robots move — motion planning, manipulation,
@@ -87,10 +87,10 @@
         <strong>Locus Robotics</strong>.
       </p>
       <ul class="hero-chips mono" aria-label="Focus areas">
-        <li>motion planning</li>
-        <li>manipulation</li>
-        <li>control</li>
-        <li>robot os</li>
+        <li>Motion Planning</li>
+        <li>Manipulation</li>
+        <li>Control</li>
+        <li>Robot OS</li>
       </ul>
       <div class="hero-actions">
         <a class="btn" href="#experience">View experience <span aria-hidden="true">&darr;</span></a>
@@ -112,7 +112,7 @@
     <!-- ============================== About ============================== -->
     <section class="container" id="about" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">01 / about</span>
+        <span class="mono section-num">01 / About</span>
         <h2>About</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -120,7 +120,7 @@
         <figure data-reveal>
           <img src="images/handguide.jpeg" alt="Tyler hand-guiding a KUKA LBR collaborative robot arm"
             width="900" height="695" loading="lazy" decoding="async">
-          <figcaption class="mono">hand-guiding a KUKA LBR</figcaption>
+          <figcaption class="mono">Hand-guiding a KUKA LBR</figcaption>
         </figure>
         <div class="about-text" data-reveal>
           <p>
@@ -154,7 +154,7 @@
     <!-- ============================== Experience ============================== -->
     <section class="container" id="experience" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">02 / experience</span>
+        <span class="mono section-num">02 / Experience</span>
         <h2>Experience</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -164,7 +164,7 @@
           <article>
             <header class="entry-head">
               <h3>Locus Robotics</h3>
-              <p class="role">Senior Robotics Engineer <span class="badge mono">current</span></p>
+              <p class="role">Senior Robotics Engineer <span class="badge mono">Current</span></p>
             </header>
             <p>
               I develop the software that runs the <a href="https://locusrobotics.com/array"
@@ -191,7 +191,7 @@
               saturation-in-the-nullspace (SNS) algorithms.
             </p>
             <div class="highlight">
-              <p class="mono highlight-label">flagship</p>
+              <p class="mono highlight-label">Flagship</p>
               <p>
                 An external jogging interface that pairs a 3D space mouse with the SNS solver: twist input
                 becomes end-effector velocity through velocity IK, integrated into joint position commands
@@ -219,7 +219,7 @@
               and visualization, QA test suites, and a robot programming IDE — plus 2D/3D vision demo systems.
             </p>
             <div class="highlight">
-              <p class="mono highlight-label">flagship</p>
+              <p class="mono highlight-label">Flagship</p>
               <p>
                 A live body-tracking follow/teach application: Azure Kinect skeleton tracking drives the arm
                 to mirror an operator's movements in real time, recording positions and motions the way a
@@ -236,7 +236,7 @@
     <!-- ============================== Projects ============================== -->
     <section class="container" id="projects" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">03 / projects</span>
+        <span class="mono section-num">03 / Projects</span>
         <h2>Projects</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -249,7 +249,7 @@
               width="800" height="500" loading="lazy" decoding="async">
           </div>
           <div class="card-body">
-            <h3><a href="aic.html">AIC Connector Insertion</a> <span class="mono card-note">private repo</span></h3>
+            <h3><a href="aic.html">AIC Connector Insertion</a> <span class="mono card-note">Private repo</span></h3>
             <p>
               Team entry to Intrinsic's AI for Industry Challenge: a fine-tuned SmolVLA
               vision-language-action policy teaching a simulated UR5e to insert fiber-optic
@@ -301,7 +301,7 @@
               width="320" height="125" loading="lazy" decoding="async">
           </div>
           <div class="card-body">
-            <h3>Impulse-VR <span class="mono card-note">private repo</span></h3>
+            <h3>Impulse-VR <span class="mono card-note">Private repo</span></h3>
             <p>
               Senior design project: a VR game you control with your brain. EEG from an OpenBCI headset
               streams over LSL into Unity, where a focus heuristic built on delta and theta band power
@@ -353,13 +353,13 @@
     <!-- ============================== Skills ============================== -->
     <section class="container" id="skills" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">04 / skills</span>
+        <span class="mono section-num">04 / Skills</span>
         <h2>Skills</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
       <div class="skills-grid">
         <div data-reveal>
-          <h3 class="mono">languages</h3>
+          <h3 class="mono">Languages</h3>
           <ul class="chips">
             <li>C / C++</li>
             <li>Python</li>
@@ -369,7 +369,7 @@
           </ul>
         </div>
         <div data-reveal>
-          <h3 class="mono">robotics</h3>
+          <h3 class="mono">Robotics</h3>
           <ul class="chips">
             <li>ROS / ROS 2</li>
             <li>Motion Planning</li>
@@ -385,7 +385,7 @@
     <!-- ============================== Contact ============================== -->
     <section class="container" id="contact" data-reveal>
       <div class="section-head">
-        <span class="mono section-num">05 / contact</span>
+        <span class="mono section-num">05 / Contact</span>
         <h2>Contact</h2>
         <span class="rule" aria-hidden="true"></span>
       </div>
@@ -394,16 +394,16 @@
       </p>
       <ul class="contact-list">
         <li>
-          <span class="mono contact-label">location</span>
+          <span class="mono contact-label">Location</span>
           <span>Boston, Massachusetts</span>
         </li>
         <li>
-          <span class="mono contact-label">linkedin</span>
+          <span class="mono contact-label">LinkedIn</span>
           <a href="https://www.linkedin.com/in/tylergjohnson0511" target="_blank"
             rel="noopener">linkedin.com/in/tylergjohnson0511</a>
         </li>
         <li>
-          <span class="mono contact-label">github</span>
+          <span class="mono contact-label">GitHub</span>
           <a href="https://github.com/johnsonTyler0511" target="_blank"
             rel="noopener">github.com/johnsonTyler0511</a>
         </li>
@@ -417,7 +417,7 @@
       <p class="mono">
         &copy; <span id="year">2026</span> Tyler Johnson &middot;
         <a href="https://github.com/johnsonTyler0511/johnsonTyler0511.github.io" target="_blank"
-          rel="noopener">source</a>
+          rel="noopener">Source</a>
       </p>
     </div>
   </footer>


### PR DESCRIPTION
## What

Two changes to the recent forest-lake restyle:

**Capitalization** — the last restyle removed `text-transform: uppercase` from the CSS, exposing literal lowercase text baked into the HTML. All nav links, eyebrows, section numbers, badges, labels, figcaptions, and card notes now use normal Title/sentence case (`About`, `Senior Robotics Engineer · Boston, MA`, `01 / About`, `Flagship`, `LinkedIn`…). The `tyler.johnson` logotype intentionally stays lowercase.

**Ocean-descent background** — replaces the dark lake look. The body background is now a gradient spanning the full document height, so scrolling goes from bright sunlit surface water down to a near-black abyss:

- Drifting wave lines at the surface (slow 80s CSS loop, scrolls away as you dive)
- Soft surface glow + faint diagonal god-rays in the upper water
- Bioluminescent cyan/seafoam/violet motes that only appear in the deep
- Full accent palette shift: seafoam links/buttons, sunlit-cyan labels, coral badges
- Cards are slightly translucent with backdrop blur so the depth shows through
- Brand mark, favicon.svg, and all three AIC diagram SVGs recolored to match
- Animations are transform/opacity only; the existing `prefers-reduced-motion` rule disables them

## Verified

- Screenshotted every depth of index, aic.html, and 404.html in headless Chrome — contrast holds at all depths (~7.8:1 text at the brightest stop, improving as it darkens)
- No horizontal scrollbar from the wave drift (`overflow-x: clip`)
- Grep sweep confirms no old-palette hex values remain

Note: `og-image.jpg` and the raster favicons are still old-palette; regenerate separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAPayq84KNDVhLjttReu1e