### PR TITLE
aic: highlight variation-bullet lead-ins in accent teal

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -762,7 +762,7 @@ html.js [data-reveal].is-visible {
 }
 
 .prose ul strong {
-  color: var(--text);
+  color: var(--accent);
 }
 
 figure.diagram {


### PR DESCRIPTION
The bolded lead-ins in the Data Pipeline variation list ("Board & rail placement", "Grasp jitter", …) were the same color as body text. This colors them with the site accent (--accent, teal) so each variation axis pops — consistent with how inline code is accented.

One-line CSS change to .prose ul strong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FZxM5HjKeXBr2SdqMPmSS